### PR TITLE
encode value and traceback information in errors

### DIFF
--- a/dispatch/sdk/v1/error.proto
+++ b/dispatch/sdk/v1/error.proto
@@ -8,6 +8,26 @@ package dispatch.sdk.v1;
 // Categorization of success and failure conditions is done via the status
 // field in the ExecuteResponse message.
 message Error {
+  // The type of error that occurred.
+  //
+  // This value is language and application specific. It is is used to provide
+  // debugging information to the user.
   string type = 1;
+
+  // A human-readable message providing more details about the error.
   string message = 2;
+
+  // A language-specific representation of the error.
+  //
+  // This field is used to enable propagation of the error value between
+  // instances of a program, by encoding information allowing the error value
+  // to be reconstructed.
+  bytes value = 3;
+
+  // The encoded stack trace for the error.
+  //
+  // The format is language-specific, encoded in the standard format used by
+  // each programming language to represent stack traces. Not all languages have
+  // stack traces for errors, so in some cases the value might be omitted.
+  bytes traceback = 4;
 }


### PR DESCRIPTION
This PR adds new fields to the `Error` message type that encode a language-dependent representation of the error and the stack trace that led to it. As a reminder, the goal is to be able to encode information about error values so they can be propagated across coroutine instances.

I debated representing these and landed on having opaque `bytes` fields. The alternatives I considered were to use the `google.protobuf.Any` type or a `oneof` over language-specific types (e.g., `dispatch.python.v1.Exception`), and I explored how to have a structured representation of the stack traces. However, I abandoned those avenues because I didn't find any use for having more complex data models; we already use `bytes` for the coroutine state, which is language-specific, so this follows a model we already use, keeping the API consistent.

Please take a look and let me know if you have different opinions on the model we should use.